### PR TITLE
🔖 v0.2.0

### DIFF
--- a/DotnetTraq.sln
+++ b/DotnetTraq.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Traq", "src\Traq\Traq.csproj", "{7D6324A1-7737-43E3-9E3A-77D85D653CF7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Traq.Tests", "src\Traq.Tests\Traq.Tests.csproj", "{D2B6E44B-E33D-40BF-BB06-59B59AACCA12}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{7D6324A1-7737-43E3-9E3A-77D85D653CF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7D6324A1-7737-43E3-9E3A-77D85D653CF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7D6324A1-7737-43E3-9E3A-77D85D653CF7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D2B6E44B-E33D-40BF-BB06-59B59AACCA12}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D2B6E44B-E33D-40BF-BB06-59B59AACCA12}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D2B6E44B-E33D-40BF-BB06-59B59AACCA12}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D2B6E44B-E33D-40BF-BB06-59B59AACCA12}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -11,13 +11,16 @@ An extension method for the `IServiceCollection` type can be used.
 In this case, a singleton instance of the `ITraqApiClient` type is provided by an `IServiceProvider` instance.
 
 ```cs
-var builder = Host.CreateApplicationBuilder();
+var host = Host.CreateDefaultApplication()
+    .ConfigureServices(services =>
+    {
+        services.AddTraqApiClient(option =>
+        {
+            option.BaseAddress = Environment.GetEnvironmentVariable("TRAQ_BASE_ADDRESS");
+            option.BearerAuthToken = Environment.GetEnvironmentVariable("TRAQ_ACCESS_TOKEN");
+        });
+    })
+    .Build();
 
-builder.Services
-    .AddTraqApiClient(conf => {
-        conf.SetBaseAddress("http://****.com/api")
-            .UseBearerAuthentication("sample_access_token")
-    });
-
-builder.Build().Run();
+host.Run();
 ```

--- a/src/Traq.Tests/Traq.Tests.csproj
+++ b/src/Traq.Tests/Traq.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Traq\Traq.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Traq/AuthenticationConfigurator.cs
+++ b/src/Traq/AuthenticationConfigurator.cs
@@ -24,13 +24,15 @@ namespace Traq
 
         public void Configure(HttpClientHandler handler, Client.Configuration conf)
         {
+            Uri baseAddress = new(conf.BasePath);
+
             handler.CookieContainer.Add(new System.Net.Cookie()
             {
                 Domain = new Uri(conf.BasePath).Host,
                 HttpOnly = true,
                 Name = "r_session",
                 Path = "/",
-                Secure = true,
+                Secure = baseAddress.Scheme == Uri.UriSchemeHttps,
                 Value = Token,
             });
         }

--- a/src/Traq/Client/WebRequestPathBuilder.cs
+++ b/src/Traq/Client/WebRequestPathBuilder.cs
@@ -22,7 +22,7 @@ namespace Traq.Client
             private string _query = "?";
             public WebRequestPathBuilder(string baseUrl, string path)
             {
-                _baseUrl = baseUrl;
+                _baseUrl = (baseUrl[^1]=='/') ? baseUrl[..^1] : baseUrl;
                 _path = path;
             }
 

--- a/src/Traq/ServiceCollectionExtensions.cs
+++ b/src/Traq/ServiceCollectionExtensions.cs
@@ -14,6 +14,7 @@ namespace Traq
         /// <param name="services">The <see cref="IServiceCollection"/> to add.</param>
         /// <param name="configure">The configurator for a new instance of the <see cref="ITraqApiClient"/> interface.</param>
         /// <returns></returns>
+        [Obsolete("Use other methods that take configurator of TraqApiClientOptions.")]
         public static IServiceCollection AddTraqApiClient(this IServiceCollection services, Action<ITraqApiClientBuilder> configure)
         {
             TraqApiClientBuilder builder = new();

--- a/src/Traq/ServiceCollectionExtensions.cs
+++ b/src/Traq/ServiceCollectionExtensions.cs
@@ -20,5 +20,18 @@ namespace Traq
             configure.Invoke(builder);
             return services.AddSingleton<ITraqApiClient>(builder.Build());
         }
+
+        /// <summary>
+        /// Adds a singleton service for the <see cref="ITraqApiClient"/> interface and a configuration for the instance to the specified <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="configure">The configurator for instances of the <see cref="ITraqApiClient"/> interface.</param>
+        /// <returns></returns>
+        public static IServiceCollection AddTraqApiClient(this IServiceCollection services, Action<TraqApiClientOptions> configure)
+        {
+            return services
+                .Configure(configure)
+                .AddSingleton<ITraqApiClient>();
+        }
     }
 }

--- a/src/Traq/Traq.csproj
+++ b/src/Traq/Traq.csproj
@@ -22,16 +22,16 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.1.0</Version>
-    <AssemblyVersion>0.1.0</AssemblyVersion>
-    <FileVersion>0.1.0.0</FileVersion>
+    <Version>0.2.0</Version>
+    <AssemblyVersion>0.2.0</AssemblyVersion>
+    <FileVersion>0.2.0.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup>
     <PackageId>Traq</PackageId>
     <NeutralLanguage>ja</NeutralLanguage>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>Generated API client using OpenAPI Generator and introduced new class that manipulates API client.</PackageReleaseNotes> <!--Set release notes here-->
+    <PackageReleaseNotes>Introduce Options type to replace Builder class for API clients.</PackageReleaseNotes> <!--Set release notes here-->
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
     <PackageTags>traq</PackageTags>

--- a/src/Traq/TraqApiClient.cs
+++ b/src/Traq/TraqApiClient.cs
@@ -1,5 +1,8 @@
-﻿using System;
+﻿using Microsoft.Extensions.Options;
+using System;
 using System.Net.Http;
+using System.Net.Http.Headers;
+using Traq.Client;
 
 namespace Traq
 {
@@ -22,6 +25,11 @@ namespace Traq
         /// Gets the configuration for this client.
         /// </summary>
         public Client.IReadableConfiguration Configuration { get; }
+
+        /// <summary>
+        /// Gets the options for this client.
+        /// </summary>
+        public IReadOnlyTraqApiClientOptions Options { get; }
 
         /// <summary>
         /// Gets the client for Activity API.
@@ -129,6 +137,8 @@ namespace Traq
     /// </summary>
     public sealed class TraqApiClient : ITraqApiClient
     {
+        readonly TraqApiClientOptions _options;
+
         /// <inheritdoc/>
         public HttpClient Client { get; }
 
@@ -137,6 +147,9 @@ namespace Traq
 
         /// <inheritdoc/>
         public Client.IReadableConfiguration Configuration { get; }
+
+        /// <inheritdoc/>
+        public IReadOnlyTraqApiClientOptions Options => _options;
 
         #region Lazy initialized APIs
 
@@ -249,7 +262,42 @@ namespace Traq
 
         #endregion
 
-        internal TraqApiClient(HttpClient client, Client.Configuration conf, HttpClientHandler? clientHandler = null)
+        /// <summary>
+        /// Initialize a new instance of the <see cref="TraqApiClient"/> class with configurated options for the instance.
+        /// </summary>
+        /// <param name="options"></param>
+        public TraqApiClient(IOptions<TraqApiClientOptions> options)
+        {
+            TraqApiClientOptions o = options.Value;
+            var (client, clientHandler) = CreateHttpClient(o);
+
+            Client = client;
+            ClientHandler = clientHandler;
+            _options = o;
+
+            _activityApi = new(() => new(client, clientHandler));
+            _authenticationApi = new(() => new(client, clientHandler));
+            _botApi = new(() => new(client, clientHandler));
+            _channelApi = new(() => new(client, clientHandler));
+            _clipApi = new(() => new(client, clientHandler));
+            _fileApi = new(() => new(client, clientHandler));
+            _groupApi = new(() => new(client, clientHandler));
+            _meApi = new(() => new(client, clientHandler));
+            _messageApi = new(() => new(client, clientHandler));
+            _notificationApi = new(() => new(client, clientHandler));
+            _oAuth2Api = new(() => new(client, clientHandler));
+            _ogpApi = new(() => new(client, clientHandler));
+            _pinApi = new(() => new(client, clientHandler));
+            _publicApi = new(() => new(client, clientHandler));
+            _stampApi = new(() => new(client, clientHandler));
+            _starApi = new(() => new(client, clientHandler));
+            _userApi = new(() => new(client, clientHandler));
+            _userTagApi = new(() => new(client, clientHandler));
+            _webhookApi = new(() => new(client, clientHandler));
+            _webRtcApi = new(() => new(client, clientHandler));
+        }
+
+        internal TraqApiClient(HttpClient client, Configuration conf, HttpClientHandler? clientHandler = null)
         {
             Client = client;
             ClientHandler = clientHandler;
@@ -282,6 +330,54 @@ namespace Traq
         {
             Client?.Dispose();
             ClientHandler?.Dispose();
+        }
+
+        static (HttpClient, HttpClientHandler) CreateHttpClient(TraqApiClientOptions options)
+        {
+            HttpClientHandler handler = new();
+            HttpClient client = new(handler);
+
+            if (options.BaseAddress is null)
+            {
+                throw new ArgumentException("Base address must be set.", nameof(options));
+            }
+
+            switch ((options.BearerAuthToken, options.CookieAuthToken))
+            {
+                case (null, null):
+                    break;
+                case (_, null):
+                    configureBearer(options, client);
+                    break;
+                case (null, _):
+                    configureCookie(options, handler);
+                    break;
+                default:
+                    if (options.AuthMethodPreference == TraqAuthMethodPreference.PreferCookieAuth)
+                        configureCookie(options, handler);
+                    else
+                        configureBearer(options, client);
+                    break;
+            }
+
+            return (client, handler);
+
+            static void configureBearer(TraqApiClientOptions o, HttpClient c)
+            {
+                c.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", o.BearerAuthToken);
+            }
+            static void configureCookie(TraqApiClientOptions o, HttpClientHandler h)
+            {
+                h.CookieContainer.Add(new System.Net.Cookie()
+                {
+                    Domain = o.BaseAddressUri.Host,
+                    HttpOnly = true,
+                    Name = "r_session",
+                    Path = "/",
+                    Secure = o.BaseAddressUri.Scheme == Uri.UriSchemeHttps,
+                    Value = o.CookieAuthToken,
+                });
+            }
         }
     }
 }

--- a/src/Traq/TraqApiClient.cs
+++ b/src/Traq/TraqApiClient.cs
@@ -24,6 +24,7 @@ namespace Traq
         /// <summary>
         /// Gets the configuration for this client.
         /// </summary>
+        [Obsolete("Use Options property instead.")]
         public Client.IReadableConfiguration Configuration { get; }
 
         /// <summary>
@@ -146,6 +147,7 @@ namespace Traq
         public HttpClientHandler? ClientHandler { get; }
 
         /// <inheritdoc/>
+        [Obsolete("Use Options property instead.")]
         public Client.IReadableConfiguration Configuration { get; }
 
         /// <inheritdoc/>
@@ -297,6 +299,7 @@ namespace Traq
             _webRtcApi = new(() => new(client, clientHandler));
         }
 
+        [Obsolete]
         internal TraqApiClient(HttpClient client, Configuration conf, HttpClientHandler? clientHandler = null)
         {
             Client = client;
@@ -324,7 +327,7 @@ namespace Traq
             _webhookApi = new(() => new(client, conf, clientHandler));
             _webRtcApi = new(() => new(client, conf, clientHandler));
         }
-        
+
         /// <inheritdoc/>
         public void Dispose()
         {

--- a/src/Traq/TraqApiClientBuilder.cs
+++ b/src/Traq/TraqApiClientBuilder.cs
@@ -6,6 +6,7 @@ namespace Traq
     /// <summary>
     /// Provides methods to build configured <see cref="ITraqApiClient"/>s.
     /// </summary>
+    [Obsolete("Use ITraqApiClientOptions interface instead.")]
     public interface ITraqApiClientBuilder
     {
         /// <summary>
@@ -39,6 +40,7 @@ namespace Traq
     /// <summary>
     /// Provides methods to build configured <see cref="TraqApiClient"/>s.
     /// </summary>
+    [Obsolete("Use TraqApiClientOptions class instead.")]
     public sealed class TraqApiClientBuilder : ITraqApiClientBuilder
     {
         IAuthenticationConfigurator? _auth;

--- a/src/Traq/TraqApiClientBuilder.cs
+++ b/src/Traq/TraqApiClientBuilder.cs
@@ -75,7 +75,8 @@ namespace Traq
         /// <inheritdoc cref="ITraqApiClientBuilder.SetBaseAddress(string)"/>
         public TraqApiClientBuilder SetBaseAddress(string baseAddress)
         {
-            _baseAddress = baseAddress;
+            ArgumentNullException.ThrowIfNull(baseAddress);
+            _baseAddress = (baseAddress.Length > 0 && baseAddress[^1] != '/') ? $"{baseAddress}/" : baseAddress;
             return this;
         }
 

--- a/src/Traq/TraqApiClientOptions.cs
+++ b/src/Traq/TraqApiClientOptions.cs
@@ -1,0 +1,92 @@
+﻿using System;
+
+namespace Traq
+{
+    public enum TraqAuthMethodPreference
+    {
+        NotSpecified = 0,
+        PreferBearerAuth,
+        PreferCookieAuth,
+    }
+
+    /// <summary>
+    /// Represents read-only options for the default service that implements the <see cref="ITraqApiClient"/> interface.
+    /// </summary>
+    public interface IReadOnlyTraqApiClientOptions
+    {
+        public abstract TraqAuthMethodPreference AuthMethodPreference { get; }
+
+        /// <summary>
+        /// Gets the base address of the traQ API.
+        /// </summary>
+        /// <returns>
+        /// The base address of the traQ API.
+        /// </returns>
+        public abstract string BaseAddress { get; }
+
+        /// <summary>
+        /// Gets the token used in bearer authentication to access the traQ API.
+        /// </summary>
+        /// <returns>The token used in bearer authentication to access the traQ API.</returns>
+        public abstract string? BearerAuthToken { get; }
+
+        /// <summary>
+        /// Gets the token used in cookie authentication to access the traQ API.
+        /// </summary>
+        /// <returns>The token used in cookie authentication to access the traQ API.</returns>
+        public abstract string? CookieAuthToken { get; }
+    }
+
+    /// <summary>
+    /// Options for the default service that implements the <see cref="ITraqApiClient"/> interface.
+    /// </summary>
+    public sealed class TraqApiClientOptions : IReadOnlyTraqApiClientOptions
+    {
+        Uri? _baseUri = null;
+
+        public TraqAuthMethodPreference AuthMethodPreference { get; set; } = TraqAuthMethodPreference.NotSpecified;
+        
+        /// <summary>
+        /// Gets or sets the base address of the traQ API.
+        /// </summary>
+        /// <value>
+        /// The base address of the traQ API.
+        /// </value>
+        /// <exception cref="UriFormatException"></exception>
+        public string BaseAddress
+        {
+            get => _baseUri?.ToString() ?? "";
+
+            set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    _baseUri = null;
+                }
+                else
+                {
+                    var address = value.AsSpan().Trim();
+                    _baseUri = new Uri((address[^1] == '/') ? address.ToString() : $"{address}/", UriKind.Absolute);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the base address of the traQ API as an instance of the <see cref="Uri"/> class.
+        /// </summary>
+        /// <returns>The base address of the traQ API. The value is <see langword="null"/> when <see cref="BaseAddress"/> is null, empty or consists of only white-space characters.</returns>
+        public Uri? BaseAddressUri => _baseUri;
+
+        /// <summary>
+        /// Gets or sets the token used in bearer authentication to access the traQ API.
+        /// </summary>
+        /// <value>The token used in bearer authentication to access the traQ API.</value>
+        public string? BearerAuthToken { get; set; } = null;
+
+        /// <summary>
+        /// Gets or sets the token used in cookie authentication to access the traQ API.
+        /// </summary>
+        /// <value>The token used in cookie authentication to access the traQ API.</value>
+        public string? CookieAuthToken { get; set; } = null;
+    }
+}

--- a/src/Traq/TraqApiClientOptions.cs
+++ b/src/Traq/TraqApiClientOptions.cs
@@ -2,10 +2,24 @@
 
 namespace Traq
 {
+    /// <summary>
+    /// Represents a preference of authentication method for the traQ API.
+    /// </summary>
     public enum TraqAuthMethodPreference
     {
+        /// <summary>
+        /// Preference is not specified.
+        /// </summary>
         NotSpecified = 0,
+
+        /// <summary>
+        /// Prefer bearer authentication.
+        /// </summary>
         PreferBearerAuth,
+
+        /// <summary>
+        /// Prefer cookie authentication.
+        /// </summary>
         PreferCookieAuth,
     }
 
@@ -14,6 +28,10 @@ namespace Traq
     /// </summary>
     public interface IReadOnlyTraqApiClientOptions
     {
+        /// <summary>
+        /// Gets the preference of authentication method for the traQ API.
+        /// </summary>
+        /// <returns>The preference of authentication method for the traQ API.</returns>
         public abstract TraqAuthMethodPreference AuthMethodPreference { get; }
 
         /// <summary>
@@ -44,6 +62,13 @@ namespace Traq
     {
         Uri? _baseUri = null;
 
+        /// <summary>
+        /// Gets or sets the preference of authentication method for the traQ API.
+        /// </summary>
+        /// <remarks>
+        /// If the value is set to <see cref="TraqAuthMethodPreference.NotSpecified"/>, this method tries to use bearer authentication in preference.
+        /// </remarks>
+        /// <value>The preference of authentication method for the traQ API.</value>
         public TraqAuthMethodPreference AuthMethodPreference { get; set; } = TraqAuthMethodPreference.NotSpecified;
         
         /// <summary>


### PR DESCRIPTION
# やったこと

- `TraqApiClientOptions` クラスを用いてクライアントの設定を行う方式に変更.
- `TraqApiClientBuilder` は今後廃止予定のため, 非推奨とした.