### PR TITLE
🐛 AddSingletonの型パラメータ設定ミス

### DIFF
--- a/src/Traq/ServiceCollectionExtensions.cs
+++ b/src/Traq/ServiceCollectionExtensions.cs
@@ -32,7 +32,7 @@ namespace Traq
         {
             return services
                 .Configure(configure)
-                .AddSingleton<ITraqApiClient>();
+                .AddSingleton<ITraqApiClient, TraqApiClient>();
         }
     }
 }

--- a/src/Traq/Traq.csproj
+++ b/src/Traq/Traq.csproj
@@ -22,16 +22,16 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.2.0</Version>
-    <AssemblyVersion>0.2.0</AssemblyVersion>
-    <FileVersion>0.2.0.0</FileVersion>
+    <Version>0.2.1</Version>
+    <AssemblyVersion>0.2.1</AssemblyVersion>
+    <FileVersion>0.2.1.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup>
     <PackageId>Traq</PackageId>
     <NeutralLanguage>ja</NeutralLanguage>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>Introduce Options type to replace Builder class for API clients.</PackageReleaseNotes> <!--Set release notes here-->
+    <PackageReleaseNotes>Fix a fatal bug on the Traq.ServiceCollectionExtensions.AddTraqApiClient method.</PackageReleaseNotes> <!--Set release notes here-->
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
     <PackageTags>traq</PackageTags>


### PR DESCRIPTION
`v0.2.0` で DI を使った場合に Bot が落ちる深刻なバグが発生してしまったので, それを修正.