### PR TITLE
🐛 クエリパラメータ内で時間は世界標準時で表現する

### DIFF
--- a/.openapi-generator-ignore
+++ b/.openapi-generator-ignore
@@ -33,3 +33,4 @@ README.md
 
 # Modified files:
 src/Traq/Client/WebRequestPathBuilder.cs
+src/Traq/Client/ClientUtils.cs

--- a/src/Traq/Client/ClientUtils.cs
+++ b/src/Traq/Client/ClientUtils.cs
@@ -93,13 +93,13 @@ namespace Traq.Client
                 // Defaults to an ISO 8601, using the known as a Round-trip date/time pattern ("o")
                 // https://msdn.microsoft.com/en-us/library/az4se3k1(v=vs.110).aspx#Anchor_8
                 // For example: 2009-06-15T13:45:30.0000000
-                return dateTime.ToString((configuration ?? GlobalConfiguration.Instance).DateTimeFormat);
+                return dateTime.ToUniversalTime().ToString((configuration ?? GlobalConfiguration.Instance).DateTimeFormat);
             if (obj is DateTimeOffset dateTimeOffset)
                 // Return a formatted date string - Can be customized with Configuration.DateTimeFormat
                 // Defaults to an ISO 8601, using the known as a Round-trip date/time pattern ("o")
                 // https://msdn.microsoft.com/en-us/library/az4se3k1(v=vs.110).aspx#Anchor_8
                 // For example: 2009-06-15T13:45:30.0000000
-                return dateTimeOffset.ToString((configuration ?? GlobalConfiguration.Instance).DateTimeFormat);
+                return dateTimeOffset.ToUniversalTime().ToString((configuration ?? GlobalConfiguration.Instance).DateTimeFormat);
             if (obj is bool boolean)
                 return boolean ? "true" : "false";
             if (obj is ICollection collection) {


### PR DESCRIPTION
- 時刻表記のオフセット部分 (`+09:00`など) を完全に無視するエンドポイントがあるので, 一律でUTCに変換してから扱うようにする.